### PR TITLE
Fix FLEX explorer visibility on call screen

### DIFF
--- a/Tweak/Call17.x
+++ b/Tweak/Call17.x
@@ -14,11 +14,11 @@ static void showFLEXExplorer() {
 			UIWindow *flexWindow = nil;
 			
 			if ([flexManager respondsToSelector:@selector(explorerWindow)]) {
-				flexWindow = [flexManager explorerWindow];
+				flexWindow = [flexManager performSelector:@selector(explorerWindow)];
 			} else if ([flexManager respondsToSelector:@selector(explorerViewController)]) {
-				id explorerVC = [flexManager explorerViewController];
+				id explorerVC = [flexManager performSelector:@selector(explorerViewController)];
 				if (explorerVC && [explorerVC respondsToSelector:@selector(view)]) {
-					UIView *view = [explorerVC view];
+					UIView *view = [explorerVC performSelector:@selector(view)];
 					flexWindow = view.window;
 				}
 			}


### PR DESCRIPTION
Fix build errors by using dynamic method calls for FLEX explorer methods.

The previous changes to show the FLEX explorer above the call screen introduced compilation errors because the FLEX methods (`explorerWindow`, `explorerViewController`, `view`) were not recognized at compile time. This PR resolves these errors by replacing direct method calls with `performSelector`, allowing for dynamic method resolution at runtime and ensuring the tweak compiles successfully.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Updated internal method invocation approach for improved compatibility. No changes to user-facing behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->